### PR TITLE
Shift page number to fix missing first page in result set

### DIFF
--- a/countless_admin/__init__.py
+++ b/countless_admin/__init__.py
@@ -91,7 +91,7 @@ class CountlessChangeList(ChangeList):
 
         # noinspection PyBroadException
         try:
-            page = self.paginator.page(self.page_num + 1)
+            page = self.paginator.page(self.page_num)
             self.result_list = list(page.object_list)
         except Exception:
             self.result_list = list()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-# Django==4.0
+Django==4.1

--- a/setup.py
+++ b/setup.py
@@ -74,9 +74,6 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',
-        'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.0',
-        'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',

--- a/test_project/test_app/tests.py
+++ b/test_project/test_app/tests.py
@@ -11,7 +11,7 @@ class CountlessAdminTestCase(TestCase):
     def setUp(self):
         self.user = User.objects.create(is_superuser=True, is_staff=True)
         self.client.force_login(self.user, None)
-        models.MyModel.objects.create()
+        self.obj = models.MyModel.objects.create()
 
     def test_no_count(self):
         """ No count queries are executed on changelist page."""
@@ -21,3 +21,7 @@ class CountlessAdminTestCase(TestCase):
         self.assertEqual(r.status_code, 200)
         for query in context.captured_queries:
             self.assertNotIn("COUNT", query['sql'])
+        opts = self.obj._meta
+        url = reverse(f'admin:{opts.app_label}_{opts.model_name}_change',
+                      args=(self.obj.pk,))
+        self.assertContains(r, url)

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,5 @@
 [tox]
 envlist =
-    {py3.7,py3.8,py3.9,py3.10,py3.11}-django2.2
-    {py3.7,py3.8,py3.9,py3.10,py3.11}-django3.0
-    {py3.7,py3.8,py3.9,py3.10,py3.11}-django3.1
     {py3.7,py3.8,py3.9,py3.10,py3.11}-django3.2
     {py3.8,py3.9,py3.10,py3.11}-django4.0
     {py3.8,py3.9,py3.10,py3.11}-django4.1


### PR DESCRIPTION
django-admin-countless counts pages incorrectly (+1 bug)
See `django.contrib.admin.views.main.ChangeList.get_results`:

```
            try:
                result_list = paginator.page(self.page_num).object_list
            except InvalidPage:
                raise IncorrectLookupParameters
```

DAC:
```
        try:
            page = self.paginator.page(self.page_num + 1)
            self.result_list = list(page.object_list)
        except Exception:
            self.result_list = list()
```